### PR TITLE
Add browser field for projects using browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.25",
   "description": "Natural Language Processing in the browser: Tokenization, Part-of-Speech tagging and more.",
   "main": "dist/compendium.js",
+  "browser": "dist/compendium.minimal.js",
   "scripts": {
     "test": "nodeunit test/*.js"
   },


### PR DESCRIPTION
Adding a `browser` field for enabling [browserify](http://browserify.org/) builds. Here's the [spec](https://github.com/defunctzombie/package-browser-field-spec) for this field.
